### PR TITLE
fix: Add slot length validation

### DIFF
--- a/app/src/app/timetable/modals/event/event.modal.html
+++ b/app/src/app/timetable/modals/event/event.modal.html
@@ -18,10 +18,14 @@
                 'm-tab__item--active': activeTab === 'customData'
             }" href="#" (click)="setActiveTab($event, 'customData')">Custom Data</a>
         </div>
-        <div class="m-alert m-alert--danger" *ngIf="conflictingSlots?.length !== 0">
+		<div class="m-alert m-alert--danger" style="margin-bottom: 5px;" *ngIf="validationInfo[0].error">
+			<h4 class="m-alert__title">{{validationInfo[0].msg}}</h4>
+			<p>Slots must be between {{validationInfo[0].minLength}} and {{validationInfo[0].maxLength}} minutes. Your slot is currently {{validationInfo[0].slotLength}} minutes in length</p>
+		</div>
+        <div class="m-alert m-alert--danger" style="margin-bottom: 5px;" *ngIf="validationInfo[1].length !== 0">
             <h4 class="m-alert__title">The following slot conflicts have been found:</h4>
             <ul>
-                <li *ngFor="let slot of conflictingSlots">
+                <li *ngFor="let slot of validationInfo[1]">
                     {{ slot.title }}: {{ slot.start * 1000 | amDateFormat:'HH:mm D MMMM' }} - {{ slot.end * 1000 | amDateFormat:'HH:mm D MMMM' }}
                 </li>
             </ul>
@@ -84,7 +88,7 @@
     <div class="o-modal__footer">
         <div class="u-display--flex u-display--justify-space-between">
             <div>
-                <button class="a-button a-button--success" (click)="save($event)" [disabled]="conflictingSlots?.length !== 0">Save</button>
+                <button class="a-button a-button--success" (click)="save($event)" [disabled]="validationInfo[1].length !== 0 || validationInfo[0].error ">Save</button>
                 <button class="a-button a-button--warning a-button--outline" (click)="close($event)">Cancel</button>
             </div>
 

--- a/app/src/app/timetable/modals/event/event.modal.ts
+++ b/app/src/app/timetable/modals/event/event.modal.ts
@@ -35,7 +35,7 @@ export class EventModalComponent implements OnInit, OnDestroy {
 	public form: FormGroup;
 	public slotTypes$: Observable<any[]>;
 	public tenant: any;
-	public conflictingSlots: Slot[];
+	public validationInfo: [any,Slot[]];
 	public activeTab = 'general';
 	public maxSlotTime: Date;
 
@@ -73,7 +73,7 @@ export class EventModalComponent implements OnInit, OnDestroy {
 							...this.data.event,
 							...this.data.event.meta.originalTimings
 						});
-						this.ensureNoConflicts();
+						this.ensureNoIssues();
 					}
 				})
 			).subscribe(tenant => this.tenant = tenant);
@@ -84,7 +84,7 @@ export class EventModalComponent implements OnInit, OnDestroy {
 				debounceTime(100)
 			)
 			.subscribe(() => setTimeout(() => {
-				this.ensureNoConflicts();
+				this.ensureNoIssues();
 			}));
 
 		// TODO: add takeuntil
@@ -100,7 +100,7 @@ export class EventModalComponent implements OnInit, OnDestroy {
 		this.maxSlotTime = moment(this.form.get('start').value).add(this.data.tenant?.settings?.maximumSlotDuration || 1440, 'm').toDate();
 	}
 
-	private ensureNoConflicts(): void {
+	private ensureNoIssues(): void {
 		this.slotService.verify({
 			...this.form.value,
 			uuid: pathOr(null, ['event', 'uuid'])(this.data),
@@ -108,7 +108,7 @@ export class EventModalComponent implements OnInit, OnDestroy {
 			end: moment(this.form.value.end).unix(),
 		})
 		.toPromise()
-		.then((slots) => this.conflictingSlots = slots);
+		.then((slots) => this.validationInfo = slots);
 	}
 
 	public canBookForOtherUsers(): boolean {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issues with slot length parameters being ignored

Issue Number: #51 

## What is the new behavior?

The /validate endpoint now also validates the slot length and returns this data to the client.
Note that the API does not itself prevent the actual booking of a slot that is too long or short, but rather the client should prevent this. This block is implemented in this PR.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Still to do: Add an entity for the length object (rather than just using any)
