### PR TITLE
Removal of "x-tenant" from frontend on API Creation

### DIFF
--- a/app/src/app/api-key/pages/create/create.page.html
+++ b/app/src/app/api-key/pages/create/create.page.html
@@ -16,7 +16,7 @@
                 label="Api key"
             ></app-text-input>
             <p class="u-hint">Fill in your own key or <a (click)="generateKey($event)" href="#">generate</a> one. Save this key before you click save because you won't be able to see it again</p>
-            <p class="u-hint" *ngIf="form.get('key').value">To use this api key in a request, apply the Basic Auth method. Or just use this: <code>Authorization: Basic {{ generateHeader() }}</code> and  <code>X-Tenant: {{ (tenant$ | async)?.uuid }}</code> </p>
+            <p class="u-hint" *ngIf="form.get('key').value">To use this api key in a request, apply the Basic Auth method. Or just use this: <code>Authorization: Basic {{ generateHeader() }}</code></p>
         </div>
         <app-permission-selector
             [formControl]="form.get('permissions')"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

On API Key Creation, it shows to include x-tenant when this is no longer need.

Issue Number: N/A

## What is the new behavior?

Just removed the x-tenant part

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Yes
