### PR TITLE
[WIP] Documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ RadioPanel open source project. It can grow thanks to the sponsors and support b
 
 ## Getting Started
 
-If you are just trying to run radiopanel, and not develop for it. You can find a guide to just get radiopanel running from prebuild images here: https://docs.radiopanel.co/self-hosting/setup
+If you are just trying to run radiopanel, and not develop for it. You can find a guide to just get radiopanel running from prebuild images here: https://docs.radiopanel.co/installation-and-setup/installing-radiopanel
 
 ### Prerequisites
 

--- a/app/src/app/install/pages/setup-station/setup-station.page.html
+++ b/app/src/app/install/pages/setup-station/setup-station.page.html
@@ -57,7 +57,7 @@
                     <p class="u-hint">
                         This field should be filled in with a link to your <code>/status-json.xsl</code> for icecast, <code>/stats?json=1</code> for shoutcast
                         or <code>/now_playing</code> for zeno. for more information regarding this URL take a look at our
-                        <a href="https://docs.radiopanel.co/quick-start#stream-settings" rel="noopener noreferrer" target="_blank">documentation</a>
+                        <a href="https://docs.radiopanel.co/installation-and-setup/configuring-radiopanel#step-3-setting-up-your-stream-information" rel="noopener noreferrer" target="_blank">documentation</a>
                     </p>
                 </div>
                 <div class="o-page__section" *ngIf="form.get('settings').get('configurationType')?.value === 'azura'">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other: Updating Documentation Links 

## What is the current behavior?

Documentation Links throughout RadioPanel was using the old documentation URLs.

Issue Number: N/A

## What is the new behavior?

Updated Links to us the new documentation URLs.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
