### PR TITLE
Permissions UI Changes

### DIFF
--- a/api/src/modules/shared/permissions.ts
+++ b/api/src/modules/shared/permissions.ts
@@ -478,7 +478,7 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 		name: 'Content permissions',
 		groups: contentTypes.map((contentType) => ({
 			name: contentType.name,
-			icon: 'align-left-justify',
+			icon: contentType.icon || 'subject',
 			permissions: [
 				{
 					label: `Create ${contentType.name}`,
@@ -503,7 +503,7 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 		name: 'Page permissions',
 		groups: pageTypes.map((pageType) => ({
 			name: pageType.name,
-			icon: 'file',
+			icon: pageType.icon || 'file',
 			permissions: [
 				// {
 				// 	label: `Create ${pageType.name}`,

--- a/api/src/modules/shared/permissions.ts
+++ b/api/src/modules/shared/permissions.ts
@@ -505,10 +505,6 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 			name: pageType.name,
 			icon: pageType.icon || 'file',
 			permissions: [
-				// {
-				// 	label: `Create ${pageType.name}`,
-				// 	value: `pages/${pageType.uuid}/create`,
-				//},
 				{
 					label: `Read ${pageType.name}`,
 					value: `pages/${pageType.uuid}/read`,
@@ -517,10 +513,6 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 					label: `Update ${pageType.name}`,
 					value: `pages/${pageType.uuid}/update`,
 				},
-				// {
-				// 	label: `Delete ${pageType.name}`,
-				// 	value: `pages/${pageType.uuid}/delete`,
-				// },
 			],
 		})),
 	}

--- a/api/src/modules/shared/permissions.ts
+++ b/api/src/modules/shared/permissions.ts
@@ -505,10 +505,10 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 			name: pageType.name,
 			icon: 'file',
 			permissions: [
-				{
-					label: `Create ${pageType.name}`,
-					value: `pages/${pageType.uuid}/create`,
-				},
+				// {
+				// 	label: `Create ${pageType.name}`,
+				// 	value: `pages/${pageType.uuid}/create`,
+				//},
 				{
 					label: `Read ${pageType.name}`,
 					value: `pages/${pageType.uuid}/read`,
@@ -517,10 +517,10 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 					label: `Update ${pageType.name}`,
 					value: `pages/${pageType.uuid}/update`,
 				},
-				{
-					label: `Delete ${pageType.name}`,
-					value: `pages/${pageType.uuid}/delete`,
-				},
+				// {
+				// 	label: `Delete ${pageType.name}`,
+				// 	value: `pages/${pageType.uuid}/delete`,
+				// },
 			],
 		})),
 	}

--- a/api/src/modules/shared/permissions.ts
+++ b/api/src/modules/shared/permissions.ts
@@ -17,7 +17,7 @@ export const permissions = (pageTypes: PageType[], contentTypes: ContentType[]) 
 			},
 			{
 				name: 'Timetable',
-				icon: 'calendar',
+				icon: 'calender',
 				permissions: [
 					{
 						label: 'View timetable',


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?

- On Permissions, the icon for `Timetable` was not loading due to a spelling mistake.
- On Permissions, the icon for `contentTypes` & `pageTypes` would not be the selected icon.
- On Permissions, the `pages/{uuid}/create` & `pages/{uuid}/delete` is visible on frontend even though it is a useless permission.

Issue Number: N/A

## What is the new behaviour?

- On Permissions, the icon for `Timetable` has been changed from `calendar` to `calender`.
- On Permissions, the icon for `contentTypes` & `pageTypes` will now show icon select or default to `subject` or `page`.
- On Permissions, the `pages/{uuid}/create` & `pages/{uuid}/delete` will no longer be visible as it has been commented out.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
