### PR TITLE
Fixed Documentation URL

### DIFF
--- a/app/src/app/install/pages/setup-station/setup-station.page.html
+++ b/app/src/app/install/pages/setup-station/setup-station.page.html
@@ -137,7 +137,7 @@
                         ></app-text-input>
                         <p class="u-hint">
                             Information on how to create a spotify client id & secret can be found
-                            <a href="https://docs.radiopanel.co/quick-start#matching-service" rel="noopener noreferrer" target="_blank">in the radiopanel docs</a>
+                            <a href="https://docs.radiopanel.co/installation-and-setup/configuring-radiopanel#step-4-setting-up-song-matching" rel="noopener noreferrer" target="_blank">in the radiopanel docs</a>
                         </p>
                     </ng-container>
                 </div>


### PR DESCRIPTION
 Fixed Documentation URL to the new Documentation Version with the current anchor to the correct section to allow new users to understand.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?

Currently, the documentation URL for instructions to setup Spotify song matching was incorrect and invalid and would return a 404 error.

Issue Number: n/A

## What is the new behaviour?

The URL has been updated allowing users to get clear assistance on how to use Spotify song matching without trying to look though the documentation,

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

n/A
